### PR TITLE
chore: Commit Speakeasy workflow.lock file

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,0 +1,30 @@
+speakeasyVersion: 1.477.0
+sources:
+    my-source:
+        sourceNamespace: my-source
+        sourceRevisionDigest: sha256:310099d6d9e4255d6b8250b333aaceebe3ebd3a89abe5409c58674b395dadde2
+        sourceBlobDigest: sha256:e7de8b6005ca5c1105304ac7af7939a76a0949ab726a905b8c8514d96f9d774a
+        tags:
+            - latest
+            - 1.0.0
+targets:
+    terraform:
+        source: my-source
+        sourceNamespace: my-source
+        sourceRevisionDigest: sha256:310099d6d9e4255d6b8250b333aaceebe3ebd3a89abe5409c58674b395dadde2
+        sourceBlobDigest: sha256:e7de8b6005ca5c1105304ac7af7939a76a0949ab726a905b8c8514d96f9d774a
+workflow:
+    workflowVersion: 1.0.0
+    speakeasyVersion: 1.477.0
+    sources:
+        my-source:
+            inputs:
+                - location: openapi.yml
+            overlays:
+                - location: overlay.yaml
+            registry:
+                location: registry.speakeasyapi.dev/epilot/epilot/my-source
+    targets:
+        terraform:
+            target: terraform
+            source: my-source


### PR DESCRIPTION
This was done without other generation related changes by:

* Getting the generator version in `.speakeasy/gen.lock` file `management.speakeasyVersion` and temporarily updating `.speakeasy/workflow.yaml` file `speakeasyVersion` to that version (temporarily replacing `latest` with a version number)
* Running `speakeasy run --skip-versioning`
* Resetting `.speakeasy/workflow.yaml` file `speakeasyVersion: latest`

This only caused the `.speakeasy/workflow.lock` file to be added.

Potential followup tasks:

* Adjust `Makefile` file `speakeasy` target to call only `speakeasy run` (use the Speakeasy workflow that automatically handles overlay and enables other workflow enhancements) instead of the deprecated `speakeasy generate sdk` command.
* Enhance `.speakeasy/workflow.yaml` file `sources.my-source` section to include `output: final.yaml` to have the Speakeasy workflow automatically output the merged source OAS and overlay file in a location of your choosing.
* Run `speakeasy run` to get latest Speakeasy generation updates